### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: npm install && npm run build

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ A shareable `config` is nothing by a module exporting a `htmllinter` config prop
 
 ## Contributing
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/anikethsaha/htmllinter)
+
 Feel free to submit PR with new features, bug fixes, docs update and other changes you think needs to be done.
 Also, submit an issue if you think needs to be corrected or implemented or needs a discussion
 


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.